### PR TITLE
require the installation to be finished before adding config file

### DIFF
--- a/manifests/config/file.pp
+++ b/manifests/config/file.pp
@@ -18,6 +18,7 @@ define supervisord::config::file (
     content => template('supervisord/etc/supervisor/service.conf.erb'),
     owner   => root,
     group   => root,
+    require => Class['supervisord::install'],
     notify  => Service['supervisor'],
   }
 }


### PR DESCRIPTION
Require the install before adding the config files.

This should fix config files being created before `/etc/supervisord/conf.d` exists.

`/etc/supervisord/conf.d` is created by the apt package